### PR TITLE
Improve awaitable handling in sentiment helper

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1,6 +1,8 @@
 """Simplified trading UI logic with sentiment analysis helpers."""
 from __future__ import annotations
 
+import asyncio
+import inspect
 from typing import Any, Dict, Optional
 
 
@@ -87,7 +89,95 @@ class MainWindow:
     # ------------------------------------------------------------------
     # Utilities
     def _await_if_needed(self, value: Any) -> Any:
-        return value
+        """Synchronously resolve ``value`` when it is awaitable.
+
+        The helper needs to cope with a variety of awaitable types used by the
+        larger project and the pared-down tests: raw coroutines, tasks and
+        futures bound to specific event loops, as well as analysers that remain
+        synchronous.  The implementation therefore
+
+        1. returns the value unchanged for non-awaitables,
+        2. short-circuits already finished futures,
+        3. reuses the awaitable's event loop when it is idle,
+        4. mirrors ``asyncio.run`` semantics by spinning up a temporary loop, and
+        5. executes work thread-safely when the awaitable is tied to a running
+           loop in another thread.
+
+        Awaitables bound to the *currently* running loop cannot be resolved
+        synchronously without risking a dead-lock; in that rare case we re-raise
+        a descriptive ``RuntimeError`` so callers can decide how to proceed.
+        """
+
+        if not inspect.isawaitable(value):
+            return value
+
+        if isinstance(value, asyncio.Future):
+            if value.done():
+                return value.result()
+
+            try:
+                target_loop = value.get_loop()
+            except RuntimeError:
+                target_loop = None
+
+            if target_loop is not None:
+                if target_loop.is_running():
+                    try:
+                        running_loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        running_loop = None
+
+                    if running_loop is target_loop:
+                        raise RuntimeError(
+                            "Cannot synchronously resolve awaitable attached to the current running event loop."
+                        )
+
+                    async def _await_on_running_loop() -> Any:
+                        return await value
+
+                    proxy = asyncio.run_coroutine_threadsafe(
+                        _await_on_running_loop(), target_loop
+                    )
+                    return proxy.result()
+
+                return self._run_awaitable_in_loop(value, loop=target_loop)
+
+        return self._run_awaitable_in_loop(value)
+
+    def _run_awaitable_in_loop(
+        self, value: Any, *, loop: Optional[asyncio.AbstractEventLoop] = None
+    ) -> Any:
+        """Execute ``value`` inside ``loop`` (or a temporary loop) and return the result."""
+
+        created_loop = loop is None
+        event_loop = loop or asyncio.new_event_loop()
+        previous_loop: Optional[asyncio.AbstractEventLoop]
+        need_restore = False
+        try:
+            try:
+                previous_loop = asyncio.get_event_loop()
+            except RuntimeError:
+                previous_loop = None
+
+            if previous_loop is not event_loop:
+                asyncio.set_event_loop(event_loop)
+                need_restore = True
+
+            async def _consume() -> Any:
+                return await value
+
+            task = event_loop.create_task(_consume())
+            event_loop.run_until_complete(task)
+            return task.result()
+        finally:
+            if need_restore:
+                if previous_loop is None:
+                    asyncio.set_event_loop(None)
+                else:
+                    asyncio.set_event_loop(previous_loop)
+
+            if created_loop:
+                event_loop.close()
 
     def _add_log(self, level: str, message: str) -> None:
         self._log_history.append((level, message))


### PR DESCRIPTION
## Summary
- expand `_await_if_needed` to support futures, tasks, and coroutines tied to specific event loops
- add `_run_awaitable_in_loop` helper to centralize synchronous resolution logic while restoring loop state

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cddc00427c8323b9ffaf111192de13